### PR TITLE
Add multi-format spreadsheet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Bio-Block is a decentralized document management system that leverages blockchai
 - **Decentralized Storage**: IPFS-based storage with encryption and secure access controls
 
 ### 🏥 Healthcare Data Management
-- **Multi-format Support**: Excel (.xlsx, .xls) and medical images (.jpg, .jpeg, .png)
+- **Multi-format Support**: Excel (.xlsx, .xls), CSV, ODS, TSV, and other spreadsheet formats (.xlsm, .xlsb), plus medical images (.jpg, .jpeg, .png)
 - **Smart Anonymization**: Wallet-based hashing for personal data, OCR+NLP for medical images
 - **Preview System**: Free 5% preview of Excel data for evaluation before purchase
 - **Metadata Collection**: Comprehensive tagging with disease types, demographics, and data sources
@@ -163,11 +163,11 @@ Access the application at `http://localhost:3000`
 
 - `GET /` - Root endpoint with API information
 - `GET /api/health` - Health check endpoint to verify server status
-- `POST /api/anonymize` - Anonymize PHI (Personal Health Information) in Excel files with optional preview generation
-  - Input: Excel file (.xlsx or .xls) via multipart form data
+- `POST /api/anonymize` - Anonymize PHI (Personal Health Information) in spreadsheet files with optional preview generation
+  - Input: Spreadsheet file (.xlsx, .xls, .csv, .ods, .tsv, .xlsm, .xlsb) via multipart form data
   - Optional: Wallet address for personal data anonymization
   - Optional: `generatePreview=true` parameter to create 5% sample preview
-  - Output: Full anonymized Excel file, and preview file (if requested) containing first 5% of rows (min 5, max 50)
+  - Output: Full anonymized spreadsheet file, and preview file (if requested) containing first 5% of rows (min 5, max 50)
 - `POST /api/ipfs/upload` - Upload a file to IPFS
   - Input: file via multipart form data
   - Output: IPFS hash of the uploaded file
@@ -214,9 +214,18 @@ curl -X POST http://localhost:3002/search_with_filter \
 curl -X POST http://localhost:3002/anonymize_image \
   -F "file=@medical_scan.jpg"
 
-# Test Excel anonymization (JavaScript backend)
+# Test spreadsheet anonymization (JavaScript backend)
 curl -X POST http://localhost:3001/api/anonymize \
   -F "file=@sample_data.xlsx" \
+  -F "generatePreview=true"
+
+# Test with different spreadsheet formats
+curl -X POST http://localhost:3001/api/anonymize \
+  -F "file=@test_sample.csv" \
+  -F "generatePreview=true"
+
+curl -X POST http://localhost:3001/api/anonymize \
+  -F "file=@test_sample.tsv" \
   -F "generatePreview=true"
 ```
 

--- a/prototype/src/upload_data.js
+++ b/prototype/src/upload_data.js
@@ -181,11 +181,11 @@ export default function UploadData({ onBack, isWalletConnected, walletAddress, o
     if (file.type.startsWith('image/')) {
       backendUrl = process.env.REACT_APP_PYTHON_BACKEND_URL || 'http://localhost:3002';
       endpoint = '/anonymize_image';
-    } else if (file.name.match(/\.(xlsx|xls)$/i)) {
+    } else if (file.name.match(/\.(xlsx|xls|csv|ods|tsv|xlsm|xlsb)$/i)) {
       backendUrl = process.env.REACT_APP_JS_BACKEND_URL || 'http://localhost:3001';
       endpoint = '/anonymize';
     } else {
-      throw new Error('File type not supported for anonymization. Only Excel (.xlsx, .xls) and image files (.jpg, .jpeg, .png) are supported.');
+      throw new Error('File type not supported for anonymization. Only Excel (.xlsx, .xls, .csv, .ods, .tsv, .xlsm, .xlsb) and image files (.jpg, .jpeg, .png) are supported.');
     }
 
     const response = await fetch(`${backendUrl}${endpoint}`, {
@@ -300,7 +300,7 @@ export default function UploadData({ onBack, isWalletConnected, walletAddress, o
       
       // Step 2: Anonymizing (if Excel or Image) and extracting preview
       updateStep(1); // Mark as in progress
-      if (selectedFile.name.match(/\.(xlsx|xls)$/i) || selectedFile.type.startsWith('image/')) {
+      if (selectedFile.name.match(/\.(xlsx|xls|csv|ods|tsv|xlsm|xlsb)$/i) || selectedFile.type.startsWith('image/')) {
         try {
           const result = await anonymizeFile(selectedFile);
           fileToUpload = result.mainFile;
@@ -314,7 +314,7 @@ export default function UploadData({ onBack, isWalletConnected, walletAddress, o
       } else {
         // File type not supported - this should not happen due to file input restrictions
         updateStep(1, false, true); // Mark as error
-        setError('File type not supported for upload. Only Excel and image files are accepted.');
+        setError('File type not supported for upload. Only Excel and spreadsheet files (.xlsx, .xls, .csv, .ods, .tsv, .xlsm, .xlsb) and image files are accepted.');
         return;
       }
       
@@ -551,7 +551,7 @@ export default function UploadData({ onBack, isWalletConnected, walletAddress, o
                     onChange={handleFileChange}
                     className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                     id="file-upload"
-                    accept=".xlsx,.xls,.jpg,.jpeg,.png"
+                    accept=".xlsx,.xls,.csv,.ods,.tsv,.xlsm,.xlsb,.jpg,.jpeg,.png"
                     disabled={!isWalletConnected}
                   />
                   
@@ -560,7 +560,7 @@ export default function UploadData({ onBack, isWalletConnected, walletAddress, o
                       {selectedFile ? selectedFile.name : 'Choose a file or drag and drop'}
                     </p>
                     <p className={`${isWalletConnected ? 'text-gray-500' : 'text-gray-400'} text-sm`}>
-                      EXCEL (XLSX, XLS) and Images (JPG, JPEG, PNG) only
+                      Spreadsheets and Images (JPG, JPEG, PNG) only
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
- Expand file format support beyond Excel to include CSV, TSV, ODS, XLSM, XLSB
- Update frontend to accept all spreadsheet formats with unified 'Spreadsheets' label